### PR TITLE
Switch over the controllers, to use the spring-boot-start-data-rest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,10 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-rest</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/bookstore/jpa/DatabaseLoader.java
+++ b/src/main/java/com/bookstore/jpa/DatabaseLoader.java
@@ -1,0 +1,52 @@
+package com.bookstore.jpa;
+
+import com.bookstore.jpa.book.Book;
+import com.bookstore.jpa.book.BookRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DatabaseLoader implements CommandLineRunner {
+
+    private final BookRepository repository;
+
+    @Autowired
+    public DatabaseLoader(BookRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public void run(String... strings) throws Exception {
+        this.repository.save(new Book(
+                "Lord of the Rings",
+                "Bretty Gud",
+                "/shiggydiggy/",
+                1992,
+                "ABC",
+                "Paperback",
+                420.69,
+                12,
+                8008.5));
+        this.repository.save(new Book(
+                "My Fair Lady",
+                "Bretty Bad",
+                "/shiggydiggy/",
+                132,
+                "ABC",
+                "Paperback",
+                420.69,
+                12,
+                8008.5));
+        this.repository.save(new Book(
+                "Hunger Game",
+                "Yeet",
+                "/shiggydiggy/",
+                132,
+                "ABC",
+                "Paperback",
+                420.69,
+                12,
+                8008.5));
+    }
+}

--- a/src/main/java/com/bookstore/jpa/book/BookRepository.java
+++ b/src/main/java/com/bookstore/jpa/book/BookRepository.java
@@ -1,7 +1,14 @@
 package com.bookstore.jpa.book;
 
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.data.repository.query.Param;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
-public interface BookRepository extends CrudRepository<Book, Long> {
-    Book findById(long id);
+import java.util.List;
+
+@RepositoryRestResource(collectionResourceRel = "books", path = "books")
+public interface BookRepository extends PagingAndSortingRepository<Book, Long> {
+    List<Book> findByTitle(@Param("title") String title);
+
+    List<Book> findByTitleContaining(@Param("title") String title);
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+spring.data.rest.base-path=/api


### PR DESCRIPTION
By switching over to the official libraries, we can save lots of time, and can use proper industry-level code to accomplish our API goals, such as CRUD, and search abilities