### PR TITLE
Fix reload glitch, by switching over to React-Dom HashRouter

### DIFF
--- a/src/main/js/Main.js
+++ b/src/main/js/Main.js
@@ -2,7 +2,8 @@ import React from "react";
 import { BrowserRouter as Router,
     Switch,
     Route,
-    Link } from "react-router-dom";
+    Link,
+    Redirect} from "react-router-dom";
 import clsx from "clsx";
 
 import {AppBar} from "@material-ui/core";
@@ -26,15 +27,11 @@ import InfoIcon from '@material-ui/icons/Info';
 import ShoppingCartIcon from '@material-ui/icons/ShoppingCart';
 import MenuBookIcon from '@material-ui/icons/MenuBook';
 import PersonIcon from '@material-ui/icons/Person';
-// React Notification
-// import 'react-notifications/lib/notifications.css';
 import { NotificationContainer } from 'react-notifications';
 import Home from "./pages/Home"
 import About from "./pages/About";
 import PublishersMenu from "./pages/PublisherInterface/PublishersMenu";
-import BookGrid from "./pages/BookInterface/BookGrid";
 import Books from "./pages/BookInterface/Books";
-import {Book} from "@material-ui/icons";
 import BookInformation from "./pages/BookInterface/BookInformation";
 
 
@@ -145,125 +142,123 @@ let Main = () => {
     };
 
     return (
-        <Router>
-            <div className={classes.root}>
-                <AppBar position="static">
-                    <Toolbar>
-                        <IconButton
-                            edge="start"
-                            onClick={handleDrawerOpen}
-                            className={clsx(classes.menuButton, open && classes.hide)}
-                            color="inherit"
-                            aria-label="open drawer"
-                        >
-                            <MenuIcon />
-                        </IconButton>
-                        <Typography className={classes.title} variant="h6" noWrap>
-                            Amazin Book Store
-                        </Typography>
-                        <div className={classes.search}>
-                            <div className={classes.searchIcon}>
-                                <SearchIcon />
-                            </div>
-                            <InputBase
-                                placeholder="Search…"
-                                classes={{
-                                    root: classes.inputRoot,
-                                    input: classes.inputInput,
-                                }}
-                                inputProps={{ 'aria-label': 'search' }}
-                            />
+        <div className={classes.root}>
+            <AppBar position="static">
+                <Toolbar>
+                    <IconButton
+                        edge="start"
+                        onClick={handleDrawerOpen}
+                        className={clsx(classes.menuButton, open && classes.hide)}
+                        color="inherit"
+                        aria-label="open drawer"
+                    >
+                        <MenuIcon />
+                    </IconButton>
+                    <Typography className={classes.title} variant="h6" noWrap>
+                        Amazin Book Store
+                    </Typography>
+                    <div className={classes.search}>
+                        <div className={classes.searchIcon}>
+                            <SearchIcon />
                         </div>
-                    </Toolbar>
-                </AppBar>
-                <Drawer
-                    className={classes.drawer}
-                    variant="persistent"
-                    anchor="left"
-                    open={open}
-                    classes={{
-                        paper: classes.drawerPaper,
-                    }}
-                >
-                    <div className={classes.drawerHeader}>
-                        <IconButton onClick={handleDrawerClose}>
-                            {theme.direction === 'ltr' ? <ChevronLeftIcon /> : <ChevronRightIcon />}
-                        </IconButton>
+                        <InputBase
+                            placeholder="Search…"
+                            classes={{
+                                root: classes.inputRoot,
+                                input: classes.inputInput,
+                            }}
+                            inputProps={{ 'aria-label': 'search' }}
+                        />
                     </div>
-                    <Divider />
-                    <List>
-                        <ListItem button component={Link} to={"/"} onClick={handleDrawerClose}>
-                            <ListItemIcon>
-                                <HomeIcon color="primary" />
-                            </ListItemIcon>
-                            <ListItemText primary="Home" />
-                        </ListItem>
-                        <ListItem button component={Link} to="/" onClick={handleDrawerClose}>
-                            <ListItemIcon>
-                                <ShoppingCartIcon color="primary" />
-                            </ListItemIcon>
-                            <ListItemText primary="My Cart" />
-                        </ListItem>
-                        <ListItem button component={Link} to="/" onClick={handleDrawerClose}>
-                            <ListItemIcon>
-                                <MenuBookIcon color="primary" />
-                            </ListItemIcon>
-                            <ListItemText primary="Recommendations" />
-                        </ListItem>
-                        <ListItem button component={Link} to="/about" onClick={handleDrawerClose}>
-                            <ListItemIcon>
-                                <InfoIcon color="primary" />
-                            </ListItemIcon>
-                            <ListItemText primary="About" />
-                        </ListItem>
-                    </List>
-                    <Divider />
-                    <List>
-                        <ListItem button component={Link} to="/" onClick={handleDrawerClose}>
-                            <ListItemIcon>
-                                <PersonIcon color="primary" />
-                            </ListItemIcon>
-                            <ListItemText primary="Authors" />
-                        </ListItem>
-                        <ListItem button component={Link} to="/Publishers" onClick={handleDrawerClose}>
-                            <ListItemIcon>
-                                <ShoppingCartIcon color="primary" />
-                            </ListItemIcon>
-                            <ListItemText primary="Publishers" />
-                        </ListItem>
-                        <ListItem button component={Link} to="/Books" onClick={handleDrawerClose}>
-                            <ListItemIcon>
-                                <MenuBookIcon color="primary" />
-                            </ListItemIcon>
-                            <ListItemText primary="Book" />
-                        </ListItem>
-                    </List>
-                </Drawer>
-
-
-                <div className="container mt-2" style={{ marginTop: 40 }}>
-                    <Switch>
-                        <Route exact path="/">
-                            <Home />
-                        </Route>
-                        <Route path="/about">
-                            <About />
-                        </Route>
-                        <Route path="/Publishers">
-                            <PublishersMenu />
-                        </Route>
-                        <Route path="/Books">
-                            <Books/>
-                        </Route>
-                        <Route path="/BookInformation">
-                            <BookInformation/>
-                        </Route>
-                    </Switch>
+                </Toolbar>
+            </AppBar>
+            <Drawer
+                className={classes.drawer}
+                variant="persistent"
+                anchor="left"
+                open={open}
+                classes={{
+                    paper: classes.drawerPaper,
+                }}
+            >
+                <div className={classes.drawerHeader}>
+                    <IconButton onClick={handleDrawerClose}>
+                        {theme.direction === 'ltr' ? <ChevronLeftIcon /> : <ChevronRightIcon />}
+                    </IconButton>
                 </div>
+                <Divider />
+                <List>
+                    <ListItem button component={Link} to={"/"} onClick={handleDrawerClose}>
+                        <ListItemIcon>
+                            <HomeIcon color="primary" />
+                        </ListItemIcon>
+                        <ListItemText primary="Home" />
+                    </ListItem>
+                    <ListItem button component={Link} to="/" onClick={handleDrawerClose}>
+                        <ListItemIcon>
+                            <ShoppingCartIcon color="primary" />
+                        </ListItemIcon>
+                        <ListItemText primary="My Cart" />
+                    </ListItem>
+                    <ListItem button component={Link} to="/" onClick={handleDrawerClose}>
+                        <ListItemIcon>
+                            <MenuBookIcon color="primary" />
+                        </ListItemIcon>
+                        <ListItemText primary="Recommendations" />
+                    </ListItem>
+                    <ListItem button component={Link} to="/about" onClick={handleDrawerClose}>
+                        <ListItemIcon>
+                            <InfoIcon color="primary" />
+                        </ListItemIcon>
+                        <ListItemText primary="About" />
+                    </ListItem>
+                </List>
+                <Divider />
+                <List>
+                    <ListItem button component={Link} to="/" onClick={handleDrawerClose}>
+                        <ListItemIcon>
+                            <PersonIcon color="primary" />
+                        </ListItemIcon>
+                        <ListItemText primary="Authors" />
+                    </ListItem>
+                    <ListItem button component={Link} to="/Publishers" onClick={handleDrawerClose}>
+                        <ListItemIcon>
+                            <ShoppingCartIcon color="primary" />
+                        </ListItemIcon>
+                        <ListItemText primary="Publishers" />
+                    </ListItem>
+                    <ListItem button component={Link} to="/Books" onClick={handleDrawerClose}>
+                        <ListItemIcon>
+                            <MenuBookIcon color="primary" />
+                        </ListItemIcon>
+                        <ListItemText primary="Book" />
+                    </ListItem>
+                </List>
+            </Drawer>
+
+
+            <div className="container mt-2" style={{ marginTop: 40 }}>
+                <Switch>
+                    <Route exact path="/">
+                        <Home />
+                    </Route>
+                    <Route path="/about">
+                        <About />
+                    </Route>
+                    <Route path="/Publishers">
+                        <PublishersMenu />
+                    </Route>
+                    <Route path="/Books">
+                        <Books/>
+                    </Route>
+                    <Route path="/BookInformation">
+                        <BookInformation/>
+                    </Route>
+                    <Redirect to={"/"} />
+                </Switch>
             </div>
             <NotificationContainer />
-        </Router>
-
+        </div>
     );
 }
 

--- a/src/main/js/index.js
+++ b/src/main/js/index.js
@@ -1,8 +1,11 @@
 import React from "react";
 import ReactDOM from "react-dom";
+import {HashRouter} from "react-router-dom";
 import Main from "./Main";
 
 ReactDOM.render(
-    <Main />,
+    <HashRouter>
+        <Main />
+    </HashRouter>,
     document.getElementById("root")
 );


### PR DESCRIPTION
It makes our URLs a bit ugly, but it works. 

Major changes:

1. Wrapped our entire Application component in the router - this is the proper way to do it. 

2. The 404 issue, is fundamentally caused because we're not treating webpages as statically served anymore. We can't directly access the server for our requests, as we're expecting requests to come in from the Javascript that we have running. The process that's being broken right now, is that the expected order of things to happen is:
i) We hit our server
ii) We get some JS that we render
iii) All the requests to the server come in FROM the JS, not from the URLs directly

The short of this fix, is that if we use React-dom HashRouters, we allow React to figure out everything past the # in the URL, and send requests for us correctly. Our endpoints don't change, nothing else has to be re-written. This is purely a React thing, that will be handled on its own. 

General React Router Knowledge: https://blog.logrocket.com/react-router-dom-set-up-essential-components-parameterized-routes-505dc93642f1/

The clusterfuck that is React Routing Solutions: https://stackoverflow.com/questions/27928372/react-router-urls-dont-work-when-refreshing-or-writing-manually

